### PR TITLE
Empty build update for testing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
     - pip
   commands:
     - pip check
-    - julia -e "using Pkg; Pkg.build("PyCall")"
+    - julia -e 'using Pkg; Pkg.build("PyCall")'
     - python -c 'import julia; julia.install(); from julia.core import Julia; Julia(compiled_modules=False); from julia import Main'
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ test:
     - pip
   commands:
     - pip check
+    - julia -e "using Pkg; Pkg.build("PyCall")"
     - python -c 'import julia; julia.install(); from julia.core import Julia; Julia(compiled_modules=False); from julia import Main'
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
     - pip
   commands:
     - pip check
-    - julia -e 'using Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'
+    - julia -e 'ENV["JULIA_PKG_SERVER"] = ""; import Pkg; Pkg.update()'
     - python -c 'import julia; julia.install(); from julia.core import Julia; Julia(compiled_modules=False); from julia import Main'
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
     - pip
   commands:
     - pip check
-    - julia -e 'using Pkg; Pkg.build("PyCall")'
+    - julia -e 'using Pkg; Pkg.add("PyCall"); Pkg.build("PyCall")'
     - python -c 'import julia; julia.install(); from julia.core import Julia; Julia(compiled_modules=False); from julia import Main'
 
 about:


### PR DESCRIPTION
I'm seeing a new issue with PyJulia installs and want to check if the latest conda-forge is failing without changes.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
